### PR TITLE
hitColor null check (somewhat specific to new horizon's carvosher)

### DIFF
--- a/src/flame/bullets/ApathySweepLaserBulletType.java
+++ b/src/flame/bullets/ApathySweepLaserBulletType.java
@@ -147,7 +147,7 @@ public class ApathySweepLaserBulletType extends BulletType{
 
                 d.hit = false;
                 d.remove();
-                dtype.hitEffect.at(d.x, d.y, d.rotation(), dtype.hitColor);
+                if(dtype.hitColor != null) dtype.hitEffect.at(d.x, d.y, d.rotation(), dtype.hitColor);
                 dtype.hitSound.at(d.x, d.y, dtype.hitSoundPitch, dtype.hitSoundVolume);
                 Effect.shake(dtype.hitShake, dtype.hitShake, d);
 


### PR DESCRIPTION
funny
log in question:
```
FATAL EXCEPTION: GLThread 7695
Process: io.anuke.mindustry, PID: 7105
java.lang.NullPointerException: Attempt to read from field 'float arc.graphics.Color.r' on a null object reference
	at arc.graphics.Color.set(Color.java:1)
	at mindustry.entities.Effect.add(Effect.java:7)
	at mindustry.entities.Effect.create(Effect.java:7)
	at mindustry.entities.Effect.at(Effect.java:6)
	at flame.bullets.ApathySweepLaserBulletType.lambda$laser$3(ApathySweepLaserBulletType.java:150)
	at flame.bullets.ApathySweepLaserBulletType$$ExternalSyntheticLambda1.get(Unknown Source:4)
	at flame.Utils.intersectLine(Utils.java:374)
	at flame.Utils.intersectLine(Utils.java:382)
	at flame.Utils.intersectLine(Utils.java:382)
	at flame.Utils.intersectLine(Utils.java:381)
	at flame.Utils.intersectLine(Utils.java:380)
	at flame.bullets.ApathySweepLaserBulletType.laser(ApathySweepLaserBulletType.java:143)
	at flame.bullets.ApathySweepLaserBulletType.update(ApathySweepLaserBulletType.java:76)
	at mindustry.gen.Bullet.update(Bullet.java:10)
	at mindustry.entities.EntityGroup.update(EntityGroup.java:2)
	at mindustry.gen.Groups.update(Groups.java:5)
	at mindustry.core.Logic.update(Logic.java:45)
	at arc.ApplicationCore.update(ApplicationCore.java:2)
	at mindustry.ClientLauncher.update(ClientLauncher.java:20)
	at arc.backend.android.AndroidGraphics.onDrawFrame(AndroidGraphics.java:22)
	at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1581)
	at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1280)
```